### PR TITLE
Enable substitution for host/auth/namespace admin

### DIFF
--- a/plugins/plugin-openwhisk/src/lib/cmds/openwhisk-core.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/openwhisk-core.ts
@@ -33,7 +33,7 @@ import { SidecarMode } from '@kui-shell/core/webapp/bottom-stripe'
 import withHeader from '../models/withHeader'
 import { synonymsTable, synonyms } from '../models/synonyms'
 import { actionSpecificModes, addActionMode, activationModes, addActivationModes } from '../models/modes'
-import { ow as globalOW, apiHost, apihost, auth as authModel, initOWFromConfig } from '../models/auth'
+import { ow as globalOW, apiHost, auth as authModel, initOWFromConfig } from '../models/auth'
 import { currentSelection } from '../models/openwhisk-entity'
 import * as repl from '@kui-shell/core/core/repl'
 import * as historyModel from '@kui-shell/core/models/history'
@@ -442,7 +442,7 @@ export const addPrettyType = (entityType: string, verb: string, entityName: stri
     entity.verb = verb
 
     // add apihost
-    entity.apiHost = apihost
+    entity.apiHost = await apiHost.get()
   }
 
   if (specials[entityType] && specials[entityType][verb]) {

--- a/plugins/plugin-openwhisk/src/lib/models/auth.ts
+++ b/plugins/plugin-openwhisk/src/lib/models/auth.ts
@@ -69,7 +69,7 @@ function getDefaultApiHost() {
  *
  *
  */
-export let apihost: string =
+let apihost: string =
   process.env.__OW_API_HOST ||
   wskprops.APIHOST ||
   store().getItem(localStorageKey.host) ||
@@ -137,7 +137,7 @@ if (getDefaultCommandContext()[0] === 'wsk' && getDefaultCommandContext()[1] ===
   initOW()
 }
 
-export const apiHost = {
+export let apiHost = {
   get: () => Promise.resolve(apihost),
   set: async (newHost: string, { ignoreCerts = false } = {}) => {
     // eslint-disable-next-line node/no-deprecated-api
@@ -160,7 +160,7 @@ export const apiHost = {
   }
 }
 
-export const auth = {
+export let auth = {
   get: () => authKey,
   getSubjectId: () => authKey.split(/:/)[0] || authKey, // if authKey is x:y, return x, otherwise return auth
   set: (newAuthKey: string): Promise<boolean> => {
@@ -172,4 +172,28 @@ export const auth = {
     debug('set', auth)
     return Promise.resolve(needReinit)
   }
+}
+
+// Swap functions related to the administrative model
+interface HostOptions {
+  ignoreCerts?: boolean
+}
+export interface APIHostService {
+  get: () => Promise<string>
+  set: (newHost: string, options?: HostOptions) => Promise<string>
+}
+export interface AuthService {
+  get: () => string
+  set: (newAuthKey: string) => Promise<boolean>
+  getSubjectId: () => string
+}
+export interface AuthModelMethods {
+  apiHost: APIHostService
+  auth: AuthService
+}
+export function swapAuthModelMethods(newMethods: AuthModelMethods): AuthModelMethods {
+  const saved = { apiHost, auth }
+  apiHost = newMethods.apiHost
+  auth = newMethods.auth
+  return saved
 }


### PR DESCRIPTION
This change is intended to make the host/auth/namespace administration (basically the capabilities of the `host` and `auth` commands and the internals controlled by them) replaceable.

The current mechanism is a dynamic swap that occurs early in startup.  I don't anticipate that this slightly incomplete mechanism will be acceptable upstream (for example, it renders usage models obsolete and misleading since it can't replace them).  A build-time capability may be added in the future.

This PR should be merged at the same time as nimbella-corp/workbench#266